### PR TITLE
Change fractions to adhere to Moodle's implementation #26

### DIFF
--- a/yui/build/moodle-atto_cloze-button/moodle-atto_cloze-button.js
+++ b/yui/build/moodle-atto_cloze-button/moodle-atto_cloze-button.js
@@ -80,11 +80,11 @@ var TEMPLATE = {
                  '<br /><label id="{{id}}_grade">{{get_string "grade" "core"}}</label>' +
                  '<select id="{{id}}_grade" value="{{fraction}}" class="{{../CSS.FRACTION}}" selected>' +
                      '{{#if fraction}}' +
-                         '<option value="{{../fraction}}">{{../fraction}}%</option>' +
+                         '<option value="{{../fraction}}">{{../fraction}}</option>' +
                      '{{/if}}' +
                      '<option value="">{{get_string "incorrect" "question"}}</option>' +
                      '{{#../fractions}}' +
-                     '<option value="{{fraction}}">{{fraction}}%</option>' +
+                     '<option value="{{fraction}}">{{fraction}}</option>' +
                      '{{/../fractions}}' +
                  '</select></div>' +
                  '<div class="{{../CSS.RIGHT}}">' +
@@ -135,8 +135,7 @@ var TEMPLATE = {
         {fraction: 80}, // 100-complementary to 20
         {fraction: 75}, // 100-complementary to 25
         {fraction: 50}, 
-        {fraction: 34}, // To be combined with 33+33+34 and give 100 in some scenarios.
-        {fraction: 33},
+        {fraction: 30},
         {fraction: 25},
         {fraction: 20},
         {fraction: 10},
@@ -146,8 +145,7 @@ var TEMPLATE = {
         {fraction: -10},
         {fraction: -20},
         {fraction: -25},
-        {fraction: -33},
-        {fraction: -34},
+        {fraction: -30},
         {fraction: -50},
         {fraction: -75},
         {fraction: -80},

--- a/yui/build/moodle-atto_cloze-button/moodle-atto_cloze-button.js
+++ b/yui/build/moodle-atto_cloze-button/moodle-atto_cloze-button.js
@@ -130,27 +130,29 @@ var TEMPLATE = {
           '</form></div>'
     },
     FRACTIONS = [{fraction: 100},
-        {fraction: 50},
-        {fraction: 33.33333},
+        {fraction: 95}, // 100-complementary to 5
+        {fraction: 90}, // 100-complementary to 10
+        {fraction: 80}, // 100-complementary to 20
+        {fraction: 75}, // 100-complementary to 25
+        {fraction: 50}, 
+        {fraction: 34}, // To be combined with 33+33+34 and give 100 in some scenarios.
+        {fraction: 33},
         {fraction: 25},
         {fraction: 20},
-        {fraction: 16.66667},
-        {fraction: 14.28571},
-        {fraction: 12.5},
-        {fraction: 11.11111},
         {fraction: 10},
         {fraction: 5},
         {fraction: 0},
         {fraction: -5},
         {fraction: -10},
-        {fraction: -11.11111},
-        {fraction: -12.5},
-        {fraction: -14.28571},
-        {fraction: -16.66667},
         {fraction: -20},
         {fraction: -25},
-        {fraction: -33.333},
+        {fraction: -33},
+        {fraction: -34},
         {fraction: -50},
+        {fraction: -75},
+        {fraction: -80},
+        {fraction: -90},
+        {fraction: -95},
         {fraction: -100}];
 
 Y.namespace('M.atto_cloze').Button = Y.Base.create('button', Y.M.editor_atto.EditorPlugin, [], {

--- a/yui/src/button/js/button.js
+++ b/yui/src/button/js/button.js
@@ -78,7 +78,7 @@ var TEMPLATE = {
                  '<br /><label id="{{id}}_grade">{{get_string "grade" "core"}}</label>' +
                  '<select id="{{id}}_grade" value="{{fraction}}" class="{{../CSS.FRACTION}}" selected>' +
                      '{{#if fraction}}' +
-                         '<option value="{{../fraction}}">{{../fraction}}%</option>' +
+                         '<option value="{{../fraction}}">{{../fraction}}</option>' +
                      '{{/if}}' +
                      '<option value="">{{get_string "incorrect" "question"}}</option>' +
                      '{{#../fractions}}' +
@@ -102,7 +102,7 @@ var TEMPLATE = {
                  '<button type="submit" class="{{CSS.CANCEL}}">{{get_string "cancel" "core"}}</button></p>' +
              '</form>' +
           '</div>',
-    OUTPUT: '&#123;{{marks}}:{{qtype}}:{{#answerdata}}~{{#if fraction}}%{{../fraction}}%{{/if}}{{answer}}' +
+    OUTPUT: '&#123;{{marks}}:{{qtype}}:{{#answerdata}}~{{#if fraction}}%{{../fraction}}{{/if}}{{answer}}' +
           '{{#if tolerance}}:{{tolerance}}{{/if}}' +
           '{{#if feedback}}#{{feedback}}{{/if}}{{/answerdata}}&#125;',
     TYPE: '<div class="atto_cloze">{{get_string "chooseqtypetoadd" "question"}}' +
@@ -128,27 +128,27 @@ var TEMPLATE = {
           '</form></div>'
     },
     FRACTIONS = [{fraction: 100},
-        {fraction: 50},
-        {fraction: 33.33333},
+        {fraction: 95}, // 100-complementary to 5
+        {fraction: 90}, // 100-complementary to 10
+        {fraction: 80}, // 100-complementary to 20
+        {fraction: 75}, // 100-complementary to 25
+        {fraction: 50}, 
+        {fraction: 30},
         {fraction: 25},
         {fraction: 20},
-        {fraction: 16.66667},
-        {fraction: 14.28571},
-        {fraction: 12.5},
-        {fraction: 11.11111},
         {fraction: 10},
         {fraction: 5},
         {fraction: 0},
         {fraction: -5},
         {fraction: -10},
-        {fraction: -11.11111},
-        {fraction: -12.5},
-        {fraction: -14.28571},
-        {fraction: -16.66667},
         {fraction: -20},
         {fraction: -25},
-        {fraction: -33.333},
+        {fraction: -30},
         {fraction: -50},
+        {fraction: -75},
+        {fraction: -80},
+        {fraction: -90},
+        {fraction: -95},
         {fraction: -100}];
 
 Y.namespace('M.atto_cloze').Button = Y.Base.create('button', Y.M.editor_atto.EditorPlugin, [], {


### PR DESCRIPTION
Moodle can't parse the decimal point in the grades of the answers in the cloze format. The regexp that moodle uses to detect the fraction scores is:

define('ANSWER_ALTERNATIVE_FRACTION_REGEX', '=|%(-?[0-9]+)%');

Hence, the grades can't be decimal. Should be integers.

Issue #26 